### PR TITLE
Feature not provable

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,3 +254,18 @@ So you should always do something like:
 ```
 
 Evaluating `one(1)` will then yield `True` as well as evaluating `one(s(z))`. But evaluating `one(B)` will yield just one possible result - `B = 1`.
+
+
+Sometimes you may also want assert that something is not provable. For that you can use a `\+`.
+You can write this operator anywhere inside the rule's body (or in the query), but you can't use it inside the rule's or fact's head. Simply put - `\+` is not valid inside a pattern.
+
+You can use it like:
+```prolog
+  isa(a).
+  test(V) :- \+ V.
+```
+
+Then you can ask like:
+```prolog
+  test(isa(b))
+```

--- a/src/ast/negation.rb
+++ b/src/ast/negation.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'set'
+
+require_relative './ast'
+
+# _, _
+class Negation < AST
+  attr_accessor :arg
+
+  def initialize(arg)
+    @arg = arg
+  end
+
+  def to_s
+    "\+ #{@arg}"
+  end
+
+  def vars
+    @arg.vars
+  end
+
+  def rename(mapping)
+    renamed = @arg.rename(mapping)
+    Negation.new(renamed)
+  end
+
+  def dup
+    Negation.new(@arg.dup)
+  end
+
+  def ==(other)
+    other.instance_of?(Negation) && @arg == other.arg
+  end
+end

--- a/src/lexer.rb
+++ b/src/lexer.rb
@@ -81,6 +81,15 @@ class Lexer
       else
         raise "Invalid token at line #{@row} column #{@col}"
       end
+    when '\\'
+      if @input[0] == '+' && @input[1] == ' '
+        r = SlashPlus(@row, @col)
+        @col += 3
+        @input = @input.drop 2
+        r
+      else
+        raise "Invalid token at line #{@row} column #{@col}"
+      end
     else
       if char >= 'a' && char <= 'z'
         @col += 1

--- a/src/lexer.rb
+++ b/src/lexer.rb
@@ -83,7 +83,7 @@ class Lexer
       end
     when '\\'
       if @input[0] == '+' && @input[1] == ' '
-        r = SlashPlus(@row, @col)
+        r = SlashPlus.new(@row, @col)
         @col += 3
         @input = @input.drop 2
         r

--- a/src/parser.rb
+++ b/src/parser.rb
@@ -8,6 +8,7 @@ require_relative './ast/junction'
 require_relative './ast/literal'
 require_relative './ast/var'
 require_relative './ast/wildcard'
+require_relative './ast/negation'
 
 # Parser of the language
 class Parser
@@ -220,16 +221,12 @@ class Parser
     tok = @lexer.next_token
 
     if tok.instance_of?(SlashPlus)
-      inside = nil
-
-      try_parse do
-        inside = first_of(
-          [method(:parse_predicate),
-           method(:parse_variable),
-           method(:parse_negation)],
-          'not a valid term'
-        )
-      end
+      inside = first_of(
+        [method(:parse_predicate),
+          method(:parse_variable),
+          method(:parse_negation)],
+        'not a valid term'
+      )
 
       return Negation.new(inside)
     end

--- a/src/parser.rb
+++ b/src/parser.rb
@@ -101,7 +101,8 @@ class Parser
 
     term = first_of(
       [method(:parse_predicate),
-       method(:parse_variable)],
+       method(:parse_variable),
+       method(:parse_negation)],
       'not a valid term'
     )
 
@@ -116,7 +117,8 @@ class Parser
         try_parse do
           right = first_of(
             [method(:parse_predicate),
-             method(:parse_variable)],
+             method(:parse_variable),
+             method(:parse_negation)],
             'not a valid term'
           )
         end
@@ -212,6 +214,27 @@ class Parser
     return Wildcard.new if tok.instance_of? Underscore
 
     raise 'not an wildcard'
+  end
+
+  def parse_negation
+    tok = @lexer.next_token
+
+    if tok.instance_of?(SlashPlus)
+      inside = nil
+
+      try_parse do
+        inside = first_of(
+          [method(:parse_predicate),
+           method(:parse_variable),
+           method(:parse_negation)],
+          'not a valid term'
+        )
+      end
+
+      return Negation.new(inside)
+    end
+
+    raise 'not a negation'
   end
 
   def parse_predicate

--- a/src/token.rb
+++ b/src/token.rb
@@ -147,3 +147,13 @@ class Underscore < Token
     @column = column
   end
 end
+
+# \+
+class SlashPlus < Token
+  attr_accessor :row, :column
+
+  def initialize(row, column)
+    @row = row
+    @column = column
+  end
+end


### PR DESCRIPTION
Implement a prefix operator `\+` aka `not provable`.

It can be used in the sequence. It is not a valid pattern or it's part.

It succeeds if it's argument is not at all provable. It fails otherwise.